### PR TITLE
Include vocabularies 2.0.1 with vulnerabilities patched

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -14,6 +14,7 @@ jobs:
           java-version: 11
       - name: Analyze with SonarCloud
         env:
+          GITHUB_NAME: ${{ secrets.DEPLOYMENT_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew build sonarqube --info

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: 11
       - name: Analyze with SonarCloud
         env:
-          GITHUB_NAME: ${{ secrets.DEPLOYMENT_NAME }}
+          GITHUB_NAME: ${{ secrets.GITHUB_ACTOR }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew build sonarqube --info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # vocabularies-app [![Java CI](https://github.com/RakipInitiative/vocabularies-app/actions/workflows/basic.yml/badge.svg)](https://github.com/RakipInitiative/vocabularies-app/actions/workflows/basic.yml) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=RakipInitiative_vocabularies-app&metric=code_smells)](https://sonarcloud.io/dashboard?id=RakipInitiative_vocabularies-app) 
 Small service exposing the vocabularies database.
 
+Building
+--------
+vocabularies-app is using the library https://github.com/RakipInitiative/vocabularies hosted in GitHub packages so authentication in GitHub is needed. Two gradle properties must be configured to fetch this library:
+* *github.packages.username* GitHub user name
+* *github.packages.password* GitHub token. The default scopes are sufficient (read public repos).
+
+This is better configured at ~/.gradle/gradle.properties. For example:
+```properties
+github.packages.username=john_doe
+github.packages.password=G4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ
+```
+
 Endpoints
 ---------
 * /availability

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ repositories {
         name 'vocabularies'
         url 'https://maven.pkg.github.com/RakipInitiative/vocabularies'
         credentials {
-            username project.findProperty("github.packages.username") ?: System.getenv("secrets.DEPLOYMENT_NAME")
-            password project.findProperty("github.packages.password") ?: System.getenv("secrets.DEPLOYMENT_TOKEN")
+            username project.findProperty("github.packages.username") ?: System.getenv("GITHUB_NAME")
+            password project.findProperty("github.packages.password") ?: System.getenv("GITHUB_TOKEN")
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,14 @@ repositories {
     mavenLocal()
     jcenter()
     maven { url 'https://kotlin.bintray.com/ktor' }
-    maven { url "https://dl.bintray.com/silebat/maven_repo" }
+    maven {
+        name 'vocabularies'
+        url 'https://maven.pkg.github.com/RakipInitiative/vocabularies'
+        credentials {
+            username project.findProperty("github.packages.username") ?: System.getenv("GITHUB_ACTOR")
+            password project.findProperty("github.packages.password") ?: System.getenv("secrets.GITHUB_TOKEN")
+        }
+    }
 }
 
 dependencies {
@@ -66,7 +73,7 @@ dependencies {
     implementation "io.ktor:ktor-server-core:$ktor_version"
     implementation "io.ktor:ktor-freemarker:$ktor_version"
     implementation "io.ktor:ktor-server-host-common:$ktor_version"
-    implementation "de.bund.bfr.rakip:vocabularies:0.0.1"
+    implementation "de.bund.bfr.rakip:vocabularies:2.0.1"
     implementation "com.h2database:h2:1.4.200"
 
     testImplementation "io.ktor:ktor-server-tests:$ktor_version"

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ repositories {
         name 'vocabularies'
         url 'https://maven.pkg.github.com/RakipInitiative/vocabularies'
         credentials {
-            username project.findProperty("github.packages.username") ?: System.getenv("GITHUB_ACTOR")
-            password project.findProperty("github.packages.password") ?: System.getenv("secrets.GITHUB_TOKEN")
+            username project.findProperty("github.packages.username") ?: System.getenv("secrets.DEPLOYMENT_NAME")
+            password project.findProperty("github.packages.password") ?: System.getenv("secrets.DEPLOYMENT_TOKEN")
         }
     }
 }


### PR DESCRIPTION
Please check locally that the app works as before (I tested it). A change though is that the vocabularies library is now hosted on GitHub Packages instead of BinTray and is necessary to authenticate into GitHub. The credentials can be configured as described in the readme.

Building
--------
vocabularies-app is using the library https://github.com/RakipInitiative/vocabularies hosted in GitHub packages so authentication in GitHub is needed. Two gradle properties must be configured to fetch this library:
* *github.packages.username* GitHub user name
* *github.packages.password* GitHub token. The default scopes are sufficient (read public repos).

This is better configured at ~/.gradle/gradle.properties. For example:
```properties
github.packages.username=john_doe
github.packages.password=G4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ
```

Please do not add credentials to the repo.