### PR TITLE
Speedup build

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -8,6 +8,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      # Cache dependencies
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/checkout@v2
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
       - name: Analyze with SonarCloud
         env:
           GITHUB_NAME: ${{ secrets.GITHUB_ACTOR }}


### PR DESCRIPTION
The dependencies are cached so that they are not downloaded in every build.